### PR TITLE
Upgrade Universal Viewer to 3.1.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "universalviewer": "^3.1"
+        "universalviewer": "^3.1.2"
       }
     },
     "node_modules/@edsilv/exjs": {
@@ -58,85 +58,62 @@
       }
     },
     "node_modules/@iiif/iiif-av-component": {
-      "version": "0.0.93",
-      "resolved": "https://registry.npmjs.org/@iiif/iiif-av-component/-/iiif-av-component-0.0.93.tgz",
-      "integrity": "sha512-HLp6A3RuEwwnpe2z1HnNoqtzluDMcPqm0EQEjQgAK8F/gYfxmioIEy0yMtzrwCeHVWjFtp4Wk/C11baDO7TfHw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@iiif/iiif-av-component/-/iiif-av-component-1.1.1.tgz",
+      "integrity": "sha512-KRf66xWBz/HWEGOreJ1foOq7LNeU/RWBAY3rTUT2cbcS8uiaM8geS06XKuEOxkyqeL12YRrM/8hoe7TExWyluQ==",
       "dependencies": {
-        "@iiif/base-component": "1.1.3",
-        "@iiif/manifold": "1.2.36",
+        "@iiif/base-component": "2.*",
+        "@iiif/manifold": "^2.0.4",
         "@types/jquery": "2.0.34",
         "@types/jqueryui": "^1.11.36",
         "exjs": "github:BSick7/exjs#0.5.1",
-        "manifesto.js": "3.0.11"
+        "manifesto.js": "^4.2.4"
       }
     },
     "node_modules/@iiif/iiif-av-component/node_modules/@iiif/base-component": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@iiif/base-component/-/base-component-1.1.3.tgz",
-      "integrity": "sha512-N9w7XfRnlV+13niU0ug7KoNRO55pBRowCF2sS60Bob4Fv98uqYh4LyL/R0z7y1yMFo5dJ6jp19p34KvwnhbUeg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@iiif/base-component/-/base-component-2.0.1.tgz",
+      "integrity": "sha512-BbIyUinIYMfre6hZYLjkhXjlt6KB9yEuO3onUQcOatBmepe8cTFNov16GzwgMcNXU2tvzCXuZLSN73Nf1295BA==",
       "dependencies": {
-        "@types/jquery": "^2.0.49",
-        "@types/node": "^7.0.65",
-        "typescript": "^2.8.3"
+        "@types/node": "8.10.52"
       }
-    },
-    "node_modules/@iiif/iiif-av-component/node_modules/@iiif/base-component/node_modules/@types/jquery": {
-      "version": "2.0.56",
-      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-2.0.56.tgz",
-      "integrity": "sha512-tcNulMBr4fuMeBhwrRNQw3JaWg7vXP9bi64nKM5qYbaIN/oyo4n9O4TG5Thyn1BmhH159XvDxD4y3kqqpYS4sg=="
-    },
-    "node_modules/@iiif/iiif-av-component/node_modules/@iiif/manifold": {
-      "version": "1.2.36",
-      "resolved": "https://registry.npmjs.org/@iiif/manifold/-/manifold-1.2.36.tgz",
-      "integrity": "sha512-0WrvgyMhQs8Hz8USjOjAIdY1HN8RtZU5vUWen3YPlQJDoFqt6O0+lm+aWLDB9PITgLLVaTwhbyiDmL9nIxG7Gg==",
-      "dependencies": {
-        "@types/jquery": "^2.0.40"
-      }
-    },
-    "node_modules/@iiif/iiif-av-component/node_modules/@iiif/manifold/node_modules/@types/jquery": {
-      "version": "2.0.56",
-      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-2.0.56.tgz",
-      "integrity": "sha512-tcNulMBr4fuMeBhwrRNQw3JaWg7vXP9bi64nKM5qYbaIN/oyo4n9O4TG5Thyn1BmhH159XvDxD4y3kqqpYS4sg=="
     },
     "node_modules/@iiif/iiif-av-component/node_modules/@types/jquery": {
       "version": "2.0.34",
       "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-2.0.34.tgz",
       "integrity": "sha1-J2FbNp8w5XIzYSZRTnRnLdpuPQQ="
     },
-    "node_modules/@iiif/iiif-av-component/node_modules/manifesto.js": {
-      "version": "3.0.11",
-      "resolved": "https://registry.npmjs.org/manifesto.js/-/manifesto.js-3.0.11.tgz",
-      "integrity": "sha512-7lPTVBX6meQccm6rZdYBWCJtK8EfBI7bScFI2bsbRe+6IH75C2Q4mtgVuk/pThN1EpdpTsSY8l5pVbAIMGMQzA==",
-      "dependencies": {
-        "http-status-codes": "github:edsilv/http-status-codes#v0.0.7",
-        "request": "^2.83.0"
-      }
+    "node_modules/@iiif/iiif-av-component/node_modules/@types/node": {
+      "version": "8.10.52",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.52.tgz",
+      "integrity": "sha512-2RbW7WXeLex6RI+kQSxq6Ym0GiVcODeQ4Km7MnnTX5BHdOGQnqVa+s6AUmAW+OFYAJ8wv9QxvNZXm7/kBdGTVw=="
     },
     "node_modules/@iiif/iiif-gallery-component": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/@iiif/iiif-gallery-component/-/iiif-gallery-component-1.1.13.tgz",
-      "integrity": "sha512-VdYAtwfJu0/asiBLyxeRill0mKyQzZSl466IYs6JFrMSkmkpcWubc7i7gM56udgEMdTU5eL5uO757d7w9PJYhg==",
+      "version": "1.1.19",
+      "resolved": "https://registry.npmjs.org/@iiif/iiif-gallery-component/-/iiif-gallery-component-1.1.19.tgz",
+      "integrity": "sha512-OHB3G0KvivufnR/9UVK9r/bb/tI8aWdfd7SvIrllZjsopAfAru2GUI+JKCko38oIk41682zVkMty2x6fSFYOYQ==",
       "dependencies": {
-        "@edsilv/exjs": "0.5.1",
-        "@edsilv/jquery-plugins": "1.0.3",
-        "@edsilv/utils": "0.2.2",
-        "@iiif/base-component": "1.1.3",
-        "@iiif/manifold": "1.2.36",
+        "@edsilv/jquery-plugins": "1.0.7",
+        "@edsilv/utils": "1.0.2",
+        "@iiif/base-component": "2.0.1",
+        "@iiif/manifold": "2.0.2",
+        "@iiif/vocabulary": "1.0.11",
         "@types/jquery": "3.3.14",
-        "manifesto.js": "3.0.9"
+        "manifesto.js": "4.0.1"
       }
     },
-    "node_modules/@iiif/iiif-gallery-component/node_modules/@edsilv/jquery-plugins": {
+    "node_modules/@iiif/iiif-gallery-component/node_modules/@edsilv/http-status-codes": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@edsilv/jquery-plugins/-/jquery-plugins-1.0.3.tgz",
-      "integrity": "sha512-nEQtgmVoKI3gELpKOGj69i1hxXIO4Ex+MaL0adPvoQiuQNj6+1+voxDCSzpkBudfiRTnjiVkhdF9By2ClTA86Q=="
+      "resolved": "https://registry.npmjs.org/@edsilv/http-status-codes/-/http-status-codes-1.0.3.tgz",
+      "integrity": "sha512-HLK2FS5sZqxPqD53D6hhZxC6C8THTVwlyZDZ7J0iWsrB8JmMA69m/CQuNKZc1kki9WSVeck2fXna26NL0SE7cg=="
     },
     "node_modules/@iiif/iiif-gallery-component/node_modules/@edsilv/utils": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@edsilv/utils/-/utils-0.2.2.tgz",
-      "integrity": "sha512-SmB5GSsYdRPxslJM1taCNN46wuA3ETrFfET4KPGm5oKKOywczv30x3pRZ4bYv3pixSc3W9fwD4QFjNMpTkH1uw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@edsilv/utils/-/utils-1.0.2.tgz",
+      "integrity": "sha512-sSq1Rcixz/X1GoL9Bf1LdAZ4icfxXARj5RgysG2eJhSuM/7QXZEbOzoayo/DJro1qJgC4j8oXCneSeKuN9qa+A==",
       "dependencies": {
-        "@types/jquery": "^2.0.40"
+        "@types/jquery": "^2.0.40",
+        "@types/node": "8.10.52"
       }
     },
     "node_modules/@iiif/iiif-gallery-component/node_modules/@edsilv/utils/node_modules/@types/jquery": {
@@ -145,32 +122,27 @@
       "integrity": "sha512-tcNulMBr4fuMeBhwrRNQw3JaWg7vXP9bi64nKM5qYbaIN/oyo4n9O4TG5Thyn1BmhH159XvDxD4y3kqqpYS4sg=="
     },
     "node_modules/@iiif/iiif-gallery-component/node_modules/@iiif/base-component": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@iiif/base-component/-/base-component-1.1.3.tgz",
-      "integrity": "sha512-N9w7XfRnlV+13niU0ug7KoNRO55pBRowCF2sS60Bob4Fv98uqYh4LyL/R0z7y1yMFo5dJ6jp19p34KvwnhbUeg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@iiif/base-component/-/base-component-2.0.1.tgz",
+      "integrity": "sha512-BbIyUinIYMfre6hZYLjkhXjlt6KB9yEuO3onUQcOatBmepe8cTFNov16GzwgMcNXU2tvzCXuZLSN73Nf1295BA==",
       "dependencies": {
-        "@types/jquery": "^2.0.49",
-        "@types/node": "^7.0.65",
-        "typescript": "^2.8.3"
+        "@types/node": "8.10.52"
       }
-    },
-    "node_modules/@iiif/iiif-gallery-component/node_modules/@iiif/base-component/node_modules/@types/jquery": {
-      "version": "2.0.56",
-      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-2.0.56.tgz",
-      "integrity": "sha512-tcNulMBr4fuMeBhwrRNQw3JaWg7vXP9bi64nKM5qYbaIN/oyo4n9O4TG5Thyn1BmhH159XvDxD4y3kqqpYS4sg=="
     },
     "node_modules/@iiif/iiif-gallery-component/node_modules/@iiif/manifold": {
-      "version": "1.2.36",
-      "resolved": "https://registry.npmjs.org/@iiif/manifold/-/manifold-1.2.36.tgz",
-      "integrity": "sha512-0WrvgyMhQs8Hz8USjOjAIdY1HN8RtZU5vUWen3YPlQJDoFqt6O0+lm+aWLDB9PITgLLVaTwhbyiDmL9nIxG7Gg==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@iiif/manifold/-/manifold-2.0.2.tgz",
+      "integrity": "sha512-wZL7JzIGL09O1yIdaI+5tGuwhtIjOyL1SJN8mHsBiRKZqahDtsp/BkDQA7xM8XzDBzUhvobYNRuLnfZ1fQTJ2Q==",
       "dependencies": {
-        "@types/jquery": "^2.0.40"
+        "@edsilv/http-status-codes": "^1.0.3",
+        "@iiif/vocabulary": "^1.0.11",
+        "manifesto.js": "4.0.1"
       }
     },
-    "node_modules/@iiif/iiif-gallery-component/node_modules/@iiif/manifold/node_modules/@types/jquery": {
-      "version": "2.0.56",
-      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-2.0.56.tgz",
-      "integrity": "sha512-tcNulMBr4fuMeBhwrRNQw3JaWg7vXP9bi64nKM5qYbaIN/oyo4n9O4TG5Thyn1BmhH159XvDxD4y3kqqpYS4sg=="
+    "node_modules/@iiif/iiif-gallery-component/node_modules/@iiif/vocabulary": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@iiif/vocabulary/-/vocabulary-1.0.11.tgz",
+      "integrity": "sha512-JjPbZ+SCn0ljsfs9Nf0U1OWNZK7tauw7iHezDJA+28AAzmMwpFS/lTOe/4N0ynZsnk4x7cA9NL6CK3K0zDd50w=="
     },
     "node_modules/@iiif/iiif-gallery-component/node_modules/@types/jquery": {
       "version": "3.3.14",
@@ -180,41 +152,51 @@
         "@types/sizzle": "*"
       }
     },
+    "node_modules/@iiif/iiif-gallery-component/node_modules/@types/node": {
+      "version": "8.10.52",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.52.tgz",
+      "integrity": "sha512-2RbW7WXeLex6RI+kQSxq6Ym0GiVcODeQ4Km7MnnTX5BHdOGQnqVa+s6AUmAW+OFYAJ8wv9QxvNZXm7/kBdGTVw=="
+    },
     "node_modules/@iiif/iiif-gallery-component/node_modules/manifesto.js": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/manifesto.js/-/manifesto.js-3.0.9.tgz",
-      "integrity": "sha512-sblQSbDmPszfwqdcSVOZp0eXIFMg7vUYJKIVTGRoO65HBppjS9ipRZ+jReV3dt5WQhI5J58KXJL97z5mcKL/pA==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/manifesto.js/-/manifesto.js-4.0.1.tgz",
+      "integrity": "sha512-COHlq5zd+qWk7rP1iWAbSN9aMw+xPpSgKl9MVvvT3RP8J7mvY4wVsifyJTPdpJBV2k8hjjvACET/Qz2tzVwcqw==",
       "dependencies": {
-        "exjs": "github:BSick7/exjs#0.5.0",
-        "http-status-codes": "github:edsilv/http-status-codes#v0.0.7",
-        "request": "^2.83.0"
+        "@edsilv/http-status-codes": "^1.0.3",
+        "@iiif/vocabulary": "^1.0.11",
+        "isomorphic-unfetch": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8.9.1",
+        "npm": ">=3.10.8"
       }
     },
     "node_modules/@iiif/iiif-metadata-component": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/@iiif/iiif-metadata-component/-/iiif-metadata-component-1.1.13.tgz",
-      "integrity": "sha512-57GboCZo+5AZwhSge1vFSs7Ax9COdIYVBBXeVr+Xohx7s935oX3wJU+TWtzw94rKzc6hPpqzsUv8hq/NnMRTBA==",
+      "version": "1.1.19",
+      "resolved": "https://registry.npmjs.org/@iiif/iiif-metadata-component/-/iiif-metadata-component-1.1.19.tgz",
+      "integrity": "sha512-ghrejvw2aTIZOFGay82dmz0LewMt0K5Dyto1veZMdAqhRUuuGFC7g9DZhGZn4238XHuOsHa6QUH2ymvmZMCPBw==",
       "dependencies": {
-        "@edsilv/exjs": "0.5.1",
-        "@edsilv/jquery-plugins": "1.0.3",
-        "@edsilv/utils": "0.2.2",
-        "@iiif/base-component": "1.1.3",
-        "@iiif/manifold": "1.2.36",
+        "@edsilv/jquery-plugins": "1.0.7",
+        "@edsilv/utils": "1.0.2",
+        "@iiif/base-component": "2.0.1",
+        "@iiif/manifold": "2.0.2",
+        "@iiif/vocabulary": "1.0.11",
         "@types/jquery": "3.3.14",
-        "manifesto.js": "3.0.9"
+        "manifesto.js": "4.0.1"
       }
     },
-    "node_modules/@iiif/iiif-metadata-component/node_modules/@edsilv/jquery-plugins": {
+    "node_modules/@iiif/iiif-metadata-component/node_modules/@edsilv/http-status-codes": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@edsilv/jquery-plugins/-/jquery-plugins-1.0.3.tgz",
-      "integrity": "sha512-nEQtgmVoKI3gELpKOGj69i1hxXIO4Ex+MaL0adPvoQiuQNj6+1+voxDCSzpkBudfiRTnjiVkhdF9By2ClTA86Q=="
+      "resolved": "https://registry.npmjs.org/@edsilv/http-status-codes/-/http-status-codes-1.0.3.tgz",
+      "integrity": "sha512-HLK2FS5sZqxPqD53D6hhZxC6C8THTVwlyZDZ7J0iWsrB8JmMA69m/CQuNKZc1kki9WSVeck2fXna26NL0SE7cg=="
     },
     "node_modules/@iiif/iiif-metadata-component/node_modules/@edsilv/utils": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@edsilv/utils/-/utils-0.2.2.tgz",
-      "integrity": "sha512-SmB5GSsYdRPxslJM1taCNN46wuA3ETrFfET4KPGm5oKKOywczv30x3pRZ4bYv3pixSc3W9fwD4QFjNMpTkH1uw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@edsilv/utils/-/utils-1.0.2.tgz",
+      "integrity": "sha512-sSq1Rcixz/X1GoL9Bf1LdAZ4icfxXARj5RgysG2eJhSuM/7QXZEbOzoayo/DJro1qJgC4j8oXCneSeKuN9qa+A==",
       "dependencies": {
-        "@types/jquery": "^2.0.40"
+        "@types/jquery": "^2.0.40",
+        "@types/node": "8.10.52"
       }
     },
     "node_modules/@iiif/iiif-metadata-component/node_modules/@edsilv/utils/node_modules/@types/jquery": {
@@ -223,32 +205,27 @@
       "integrity": "sha512-tcNulMBr4fuMeBhwrRNQw3JaWg7vXP9bi64nKM5qYbaIN/oyo4n9O4TG5Thyn1BmhH159XvDxD4y3kqqpYS4sg=="
     },
     "node_modules/@iiif/iiif-metadata-component/node_modules/@iiif/base-component": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@iiif/base-component/-/base-component-1.1.3.tgz",
-      "integrity": "sha512-N9w7XfRnlV+13niU0ug7KoNRO55pBRowCF2sS60Bob4Fv98uqYh4LyL/R0z7y1yMFo5dJ6jp19p34KvwnhbUeg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@iiif/base-component/-/base-component-2.0.1.tgz",
+      "integrity": "sha512-BbIyUinIYMfre6hZYLjkhXjlt6KB9yEuO3onUQcOatBmepe8cTFNov16GzwgMcNXU2tvzCXuZLSN73Nf1295BA==",
       "dependencies": {
-        "@types/jquery": "^2.0.49",
-        "@types/node": "^7.0.65",
-        "typescript": "^2.8.3"
+        "@types/node": "8.10.52"
       }
-    },
-    "node_modules/@iiif/iiif-metadata-component/node_modules/@iiif/base-component/node_modules/@types/jquery": {
-      "version": "2.0.56",
-      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-2.0.56.tgz",
-      "integrity": "sha512-tcNulMBr4fuMeBhwrRNQw3JaWg7vXP9bi64nKM5qYbaIN/oyo4n9O4TG5Thyn1BmhH159XvDxD4y3kqqpYS4sg=="
     },
     "node_modules/@iiif/iiif-metadata-component/node_modules/@iiif/manifold": {
-      "version": "1.2.36",
-      "resolved": "https://registry.npmjs.org/@iiif/manifold/-/manifold-1.2.36.tgz",
-      "integrity": "sha512-0WrvgyMhQs8Hz8USjOjAIdY1HN8RtZU5vUWen3YPlQJDoFqt6O0+lm+aWLDB9PITgLLVaTwhbyiDmL9nIxG7Gg==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@iiif/manifold/-/manifold-2.0.2.tgz",
+      "integrity": "sha512-wZL7JzIGL09O1yIdaI+5tGuwhtIjOyL1SJN8mHsBiRKZqahDtsp/BkDQA7xM8XzDBzUhvobYNRuLnfZ1fQTJ2Q==",
       "dependencies": {
-        "@types/jquery": "^2.0.40"
+        "@edsilv/http-status-codes": "^1.0.3",
+        "@iiif/vocabulary": "^1.0.11",
+        "manifesto.js": "4.0.1"
       }
     },
-    "node_modules/@iiif/iiif-metadata-component/node_modules/@iiif/manifold/node_modules/@types/jquery": {
-      "version": "2.0.56",
-      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-2.0.56.tgz",
-      "integrity": "sha512-tcNulMBr4fuMeBhwrRNQw3JaWg7vXP9bi64nKM5qYbaIN/oyo4n9O4TG5Thyn1BmhH159XvDxD4y3kqqpYS4sg=="
+    "node_modules/@iiif/iiif-metadata-component/node_modules/@iiif/vocabulary": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@iiif/vocabulary/-/vocabulary-1.0.11.tgz",
+      "integrity": "sha512-JjPbZ+SCn0ljsfs9Nf0U1OWNZK7tauw7iHezDJA+28AAzmMwpFS/lTOe/4N0ynZsnk4x7cA9NL6CK3K0zDd50w=="
     },
     "node_modules/@iiif/iiif-metadata-component/node_modules/@types/jquery": {
       "version": "3.3.14",
@@ -258,14 +235,23 @@
         "@types/sizzle": "*"
       }
     },
+    "node_modules/@iiif/iiif-metadata-component/node_modules/@types/node": {
+      "version": "8.10.52",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.52.tgz",
+      "integrity": "sha512-2RbW7WXeLex6RI+kQSxq6Ym0GiVcODeQ4Km7MnnTX5BHdOGQnqVa+s6AUmAW+OFYAJ8wv9QxvNZXm7/kBdGTVw=="
+    },
     "node_modules/@iiif/iiif-metadata-component/node_modules/manifesto.js": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/manifesto.js/-/manifesto.js-3.0.9.tgz",
-      "integrity": "sha512-sblQSbDmPszfwqdcSVOZp0eXIFMg7vUYJKIVTGRoO65HBppjS9ipRZ+jReV3dt5WQhI5J58KXJL97z5mcKL/pA==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/manifesto.js/-/manifesto.js-4.0.1.tgz",
+      "integrity": "sha512-COHlq5zd+qWk7rP1iWAbSN9aMw+xPpSgKl9MVvvT3RP8J7mvY4wVsifyJTPdpJBV2k8hjjvACET/Qz2tzVwcqw==",
       "dependencies": {
-        "exjs": "github:BSick7/exjs#0.5.0",
-        "http-status-codes": "github:edsilv/http-status-codes#v0.0.7",
-        "request": "^2.83.0"
+        "@edsilv/http-status-codes": "^1.0.3",
+        "@iiif/vocabulary": "^1.0.11",
+        "isomorphic-unfetch": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8.9.1",
+        "npm": ">=3.10.8"
       }
     },
     "node_modules/@iiif/iiif-tree-component": {
@@ -326,13 +312,24 @@
       }
     },
     "node_modules/@iiif/manifold": {
-      "version": "1.2.38",
-      "resolved": "https://registry.npmjs.org/@iiif/manifold/-/manifold-1.2.38.tgz",
-      "integrity": "sha512-Bafem30hh7m3Zt6IP2S1cfaBoe8N6owMMCX8ogya/BJgu/7pO+RivVndOkYNAYrA3lyQ3YA9g8NRDB+w4vAorQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@iiif/manifold/-/manifold-2.0.4.tgz",
+      "integrity": "sha512-ANxF5gyulwejdi7GsyVVzNt5Ehch0RUd3pMa1t5K8fUxehV4iSModyvB5z3o4EHFeRjUljgK+pL589rlkwo5Og==",
       "dependencies": {
-        "@types/jquery": "^2.0.40",
-        "natives": "^1.1.6"
+        "@edsilv/http-status-codes": "^1.0.3",
+        "@iiif/vocabulary": "^1.0.20",
+        "manifesto.js": "^4.2.4"
       }
+    },
+    "node_modules/@iiif/manifold/node_modules/@edsilv/http-status-codes": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@edsilv/http-status-codes/-/http-status-codes-1.0.3.tgz",
+      "integrity": "sha512-HLK2FS5sZqxPqD53D6hhZxC6C8THTVwlyZDZ7J0iWsrB8JmMA69m/CQuNKZc1kki9WSVeck2fXna26NL0SE7cg=="
+    },
+    "node_modules/@iiif/vocabulary": {
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/@iiif/vocabulary/-/vocabulary-1.0.20.tgz",
+      "integrity": "sha512-cL30/fL+7D+3tJvgGNZE6jWWGe/03ooEmwIfZEezbSE8mNzJB1pKthOrERKbeoMPdk1Qc++ySPgbgeawtYiFzA=="
     },
     "node_modules/@types/jquery": {
       "version": "2.0.56",
@@ -1038,6 +1035,15 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
     },
+    "node_modules/isomorphic-unfetch": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-unfetch/-/isomorphic-unfetch-3.1.0.tgz",
+      "integrity": "sha512-geDJjpoZ8N0kWexiwkX8F9NkTsXhetLPVbZFQ+JTW239QNOwvB0gniuR1Wc6f0AMTn7/mFGyXvHTifrCp/GH8Q==",
+      "dependencies": {
+        "node-fetch": "^2.6.1",
+        "unfetch": "^4.2.0"
+      }
+    },
     "node_modules/isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
@@ -1170,13 +1176,29 @@
       "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
     "node_modules/manifesto.js": {
-      "version": "3.0.12",
-      "resolved": "https://registry.npmjs.org/manifesto.js/-/manifesto.js-3.0.12.tgz",
-      "integrity": "sha512-AUrU2YH+TJW4BvgJrU1tPLH9wZZvNSSsgSha+4Sdei80/wUQqnUOFhTOkiYaf8fPNQa3nbaXnbbzz835vX8r3Q==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/manifesto.js/-/manifesto.js-4.2.4.tgz",
+      "integrity": "sha512-Kfa3RSFnWeLTmzpkRQu/WM1275cx859rzwQO0wiRVo3Kl3yjbyV7QPzZkLCqgaL76gOarfYe28t1EDytgGpL9A==",
       "dependencies": {
-        "http-status-codes": "github:edsilv/http-status-codes#v0.0.7",
-        "request": "^2.83.0"
+        "@edsilv/http-status-codes": "^1.0.3",
+        "@iiif/vocabulary": "^1.0.20",
+        "isomorphic-unfetch": "^3.0.0",
+        "lodash": "^4.17.21"
+      },
+      "engines": {
+        "node": ">=8.9.1",
+        "npm": ">=3.10.8"
       }
+    },
+    "node_modules/manifesto.js/node_modules/@edsilv/http-status-codes": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@edsilv/http-status-codes/-/http-status-codes-1.0.3.tgz",
+      "integrity": "sha512-HLK2FS5sZqxPqD53D6hhZxC6C8THTVwlyZDZ7J0iWsrB8JmMA69m/CQuNKZc1kki9WSVeck2fXna26NL0SE7cg=="
+    },
+    "node_modules/manifesto.js/node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/marks-pane": {
       "version": "1.0.9",
@@ -1236,12 +1258,6 @@
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
     },
-    "node_modules/natives": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.6.tgz",
-      "integrity": "sha512-6+TDFewD4yxY14ptjKaS63GVdtKiES1pTPyxn9Jb0rBqPMZ7VcCiooEhPNsr+mqHtMGxa/5c/HhcC4uPEUw/nA==",
-      "deprecated": "This module relies on Node.js's internals and will break at some point. Do not use it, and update to graceful-fs@4.x."
-    },
     "node_modules/next-tick": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
@@ -1251,6 +1267,14 @@
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/node-ensure/-/node-ensure-0.0.0.tgz",
       "integrity": "sha1-7K52QVDemYYexcgQ/V0Jaxg5Mqc="
+    },
+    "node_modules/node-fetch": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      }
     },
     "node_modules/oauth-sign": {
       "version": "0.9.0",
@@ -1728,12 +1752,16 @@
         "node": ">=4.2.0"
       }
     },
+    "node_modules/unfetch": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/unfetch/-/unfetch-4.2.0.tgz",
+      "integrity": "sha512-F9p7yYCn6cIW9El1zi0HI6vqpeIvBsr3dSuRO6Xuppb1u5rXpCPmMvLSyECLhybr9isec8Ohl0hPekMVrEinDA=="
+    },
     "node_modules/universalviewer": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/universalviewer/-/universalviewer-3.1.1.tgz",
-      "integrity": "sha512-OiVFrvVX6GhDSt/g3fW6L/2SNzv0q3igvb1vmvLMcGVZBjle4P/oggNR7jx20mmVS8rNvnMUQD80Ay32O220hw==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/universalviewer/-/universalviewer-3.1.2.tgz",
+      "integrity": "sha512-QhEIwvJW6IKfAUMKzhPNDVLAGHx8uavhZqOrtQOuVV7ETwSh5iD3rGflPpSuF+mfGgkCMdg+8pXIG1DgcFUKFg==",
       "hasInstallScript": true,
-      "license": "MIT",
       "dependencies": {
         "@edsilv/exjs": "0.5.1",
         "@edsilv/http-status-codes": "0.0.12",
@@ -1741,11 +1769,12 @@
         "@edsilv/key-codes": "0.0.9",
         "@edsilv/utils": "0.2.6",
         "@iiif/base-component": "1.1.4",
-        "@iiif/iiif-av-component": "0.0.93",
-        "@iiif/iiif-gallery-component": "1.1.13",
-        "@iiif/iiif-metadata-component": "1.1.13",
+        "@iiif/iiif-av-component": "^1.1.1",
+        "@iiif/iiif-gallery-component": "1.1.19",
+        "@iiif/iiif-metadata-component": "1.1.19",
         "@iiif/iiif-tree-component": "1.1.16",
-        "@iiif/manifold": "1.2.38",
+        "@iiif/manifold": "^2.0.4",
+        "@iiif/vocabulary": "^1.0.20",
         "@types/modernizr": "3.2.29",
         "@types/requirejs": "2.1.28",
         "@types/three": "0.84.20",
@@ -1760,7 +1789,7 @@
         "jquery-ui-dist": "1.12.1",
         "jquery-ui-touch-punch": "0.2.3",
         "jsviews": "0.9.83",
-        "manifesto.js": "3.0.12",
+        "manifesto.js": "^4.2.4",
         "mediaelement": "4.0.2",
         "opencollective": "1.0.3",
         "openseadragon": "2.2.1",
@@ -1954,48 +1983,24 @@
       }
     },
     "@iiif/iiif-av-component": {
-      "version": "0.0.93",
-      "resolved": "https://registry.npmjs.org/@iiif/iiif-av-component/-/iiif-av-component-0.0.93.tgz",
-      "integrity": "sha512-HLp6A3RuEwwnpe2z1HnNoqtzluDMcPqm0EQEjQgAK8F/gYfxmioIEy0yMtzrwCeHVWjFtp4Wk/C11baDO7TfHw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@iiif/iiif-av-component/-/iiif-av-component-1.1.1.tgz",
+      "integrity": "sha512-KRf66xWBz/HWEGOreJ1foOq7LNeU/RWBAY3rTUT2cbcS8uiaM8geS06XKuEOxkyqeL12YRrM/8hoe7TExWyluQ==",
       "requires": {
-        "@iiif/base-component": "1.1.3",
-        "@iiif/manifold": "1.2.36",
+        "@iiif/base-component": "2.*",
+        "@iiif/manifold": "^2.0.4",
         "@types/jquery": "2.0.34",
         "@types/jqueryui": "^1.11.36",
         "exjs": "github:BSick7/exjs#0.5.1",
-        "manifesto.js": "3.0.11"
+        "manifesto.js": "^4.2.4"
       },
       "dependencies": {
         "@iiif/base-component": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/@iiif/base-component/-/base-component-1.1.3.tgz",
-          "integrity": "sha512-N9w7XfRnlV+13niU0ug7KoNRO55pBRowCF2sS60Bob4Fv98uqYh4LyL/R0z7y1yMFo5dJ6jp19p34KvwnhbUeg==",
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/@iiif/base-component/-/base-component-2.0.1.tgz",
+          "integrity": "sha512-BbIyUinIYMfre6hZYLjkhXjlt6KB9yEuO3onUQcOatBmepe8cTFNov16GzwgMcNXU2tvzCXuZLSN73Nf1295BA==",
           "requires": {
-            "@types/jquery": "^2.0.49",
-            "@types/node": "^7.0.65",
-            "typescript": "^2.8.3"
-          },
-          "dependencies": {
-            "@types/jquery": {
-              "version": "2.0.56",
-              "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-2.0.56.tgz",
-              "integrity": "sha512-tcNulMBr4fuMeBhwrRNQw3JaWg7vXP9bi64nKM5qYbaIN/oyo4n9O4TG5Thyn1BmhH159XvDxD4y3kqqpYS4sg=="
-            }
-          }
-        },
-        "@iiif/manifold": {
-          "version": "1.2.36",
-          "resolved": "https://registry.npmjs.org/@iiif/manifold/-/manifold-1.2.36.tgz",
-          "integrity": "sha512-0WrvgyMhQs8Hz8USjOjAIdY1HN8RtZU5vUWen3YPlQJDoFqt6O0+lm+aWLDB9PITgLLVaTwhbyiDmL9nIxG7Gg==",
-          "requires": {
-            "@types/jquery": "^2.0.40"
-          },
-          "dependencies": {
-            "@types/jquery": {
-              "version": "2.0.56",
-              "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-2.0.56.tgz",
-              "integrity": "sha512-tcNulMBr4fuMeBhwrRNQw3JaWg7vXP9bi64nKM5qYbaIN/oyo4n9O4TG5Thyn1BmhH159XvDxD4y3kqqpYS4sg=="
-            }
+            "@types/node": "8.10.52"
           }
         },
         "@types/jquery": {
@@ -2003,42 +2008,39 @@
           "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-2.0.34.tgz",
           "integrity": "sha1-J2FbNp8w5XIzYSZRTnRnLdpuPQQ="
         },
-        "manifesto.js": {
-          "version": "3.0.11",
-          "resolved": "https://registry.npmjs.org/manifesto.js/-/manifesto.js-3.0.11.tgz",
-          "integrity": "sha512-7lPTVBX6meQccm6rZdYBWCJtK8EfBI7bScFI2bsbRe+6IH75C2Q4mtgVuk/pThN1EpdpTsSY8l5pVbAIMGMQzA==",
-          "requires": {
-            "http-status-codes": "github:edsilv/http-status-codes#v0.0.7",
-            "request": "^2.83.0"
-          }
+        "@types/node": {
+          "version": "8.10.52",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.52.tgz",
+          "integrity": "sha512-2RbW7WXeLex6RI+kQSxq6Ym0GiVcODeQ4Km7MnnTX5BHdOGQnqVa+s6AUmAW+OFYAJ8wv9QxvNZXm7/kBdGTVw=="
         }
       }
     },
     "@iiif/iiif-gallery-component": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/@iiif/iiif-gallery-component/-/iiif-gallery-component-1.1.13.tgz",
-      "integrity": "sha512-VdYAtwfJu0/asiBLyxeRill0mKyQzZSl466IYs6JFrMSkmkpcWubc7i7gM56udgEMdTU5eL5uO757d7w9PJYhg==",
+      "version": "1.1.19",
+      "resolved": "https://registry.npmjs.org/@iiif/iiif-gallery-component/-/iiif-gallery-component-1.1.19.tgz",
+      "integrity": "sha512-OHB3G0KvivufnR/9UVK9r/bb/tI8aWdfd7SvIrllZjsopAfAru2GUI+JKCko38oIk41682zVkMty2x6fSFYOYQ==",
       "requires": {
-        "@edsilv/exjs": "0.5.1",
-        "@edsilv/jquery-plugins": "1.0.3",
-        "@edsilv/utils": "0.2.2",
-        "@iiif/base-component": "1.1.3",
-        "@iiif/manifold": "1.2.36",
+        "@edsilv/jquery-plugins": "1.0.7",
+        "@edsilv/utils": "1.0.2",
+        "@iiif/base-component": "2.0.1",
+        "@iiif/manifold": "2.0.2",
+        "@iiif/vocabulary": "1.0.11",
         "@types/jquery": "3.3.14",
-        "manifesto.js": "3.0.9"
+        "manifesto.js": "4.0.1"
       },
       "dependencies": {
-        "@edsilv/jquery-plugins": {
+        "@edsilv/http-status-codes": {
           "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/@edsilv/jquery-plugins/-/jquery-plugins-1.0.3.tgz",
-          "integrity": "sha512-nEQtgmVoKI3gELpKOGj69i1hxXIO4Ex+MaL0adPvoQiuQNj6+1+voxDCSzpkBudfiRTnjiVkhdF9By2ClTA86Q=="
+          "resolved": "https://registry.npmjs.org/@edsilv/http-status-codes/-/http-status-codes-1.0.3.tgz",
+          "integrity": "sha512-HLK2FS5sZqxPqD53D6hhZxC6C8THTVwlyZDZ7J0iWsrB8JmMA69m/CQuNKZc1kki9WSVeck2fXna26NL0SE7cg=="
         },
         "@edsilv/utils": {
-          "version": "0.2.2",
-          "resolved": "https://registry.npmjs.org/@edsilv/utils/-/utils-0.2.2.tgz",
-          "integrity": "sha512-SmB5GSsYdRPxslJM1taCNN46wuA3ETrFfET4KPGm5oKKOywczv30x3pRZ4bYv3pixSc3W9fwD4QFjNMpTkH1uw==",
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/@edsilv/utils/-/utils-1.0.2.tgz",
+          "integrity": "sha512-sSq1Rcixz/X1GoL9Bf1LdAZ4icfxXARj5RgysG2eJhSuM/7QXZEbOzoayo/DJro1qJgC4j8oXCneSeKuN9qa+A==",
           "requires": {
-            "@types/jquery": "^2.0.40"
+            "@types/jquery": "^2.0.40",
+            "@types/node": "8.10.52"
           },
           "dependencies": {
             "@types/jquery": {
@@ -2049,36 +2051,27 @@
           }
         },
         "@iiif/base-component": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/@iiif/base-component/-/base-component-1.1.3.tgz",
-          "integrity": "sha512-N9w7XfRnlV+13niU0ug7KoNRO55pBRowCF2sS60Bob4Fv98uqYh4LyL/R0z7y1yMFo5dJ6jp19p34KvwnhbUeg==",
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/@iiif/base-component/-/base-component-2.0.1.tgz",
+          "integrity": "sha512-BbIyUinIYMfre6hZYLjkhXjlt6KB9yEuO3onUQcOatBmepe8cTFNov16GzwgMcNXU2tvzCXuZLSN73Nf1295BA==",
           "requires": {
-            "@types/jquery": "^2.0.49",
-            "@types/node": "^7.0.65",
-            "typescript": "^2.8.3"
-          },
-          "dependencies": {
-            "@types/jquery": {
-              "version": "2.0.56",
-              "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-2.0.56.tgz",
-              "integrity": "sha512-tcNulMBr4fuMeBhwrRNQw3JaWg7vXP9bi64nKM5qYbaIN/oyo4n9O4TG5Thyn1BmhH159XvDxD4y3kqqpYS4sg=="
-            }
+            "@types/node": "8.10.52"
           }
         },
         "@iiif/manifold": {
-          "version": "1.2.36",
-          "resolved": "https://registry.npmjs.org/@iiif/manifold/-/manifold-1.2.36.tgz",
-          "integrity": "sha512-0WrvgyMhQs8Hz8USjOjAIdY1HN8RtZU5vUWen3YPlQJDoFqt6O0+lm+aWLDB9PITgLLVaTwhbyiDmL9nIxG7Gg==",
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/@iiif/manifold/-/manifold-2.0.2.tgz",
+          "integrity": "sha512-wZL7JzIGL09O1yIdaI+5tGuwhtIjOyL1SJN8mHsBiRKZqahDtsp/BkDQA7xM8XzDBzUhvobYNRuLnfZ1fQTJ2Q==",
           "requires": {
-            "@types/jquery": "^2.0.40"
-          },
-          "dependencies": {
-            "@types/jquery": {
-              "version": "2.0.56",
-              "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-2.0.56.tgz",
-              "integrity": "sha512-tcNulMBr4fuMeBhwrRNQw3JaWg7vXP9bi64nKM5qYbaIN/oyo4n9O4TG5Thyn1BmhH159XvDxD4y3kqqpYS4sg=="
-            }
+            "@edsilv/http-status-codes": "^1.0.3",
+            "@iiif/vocabulary": "^1.0.11",
+            "manifesto.js": "4.0.1"
           }
+        },
+        "@iiif/vocabulary": {
+          "version": "1.0.11",
+          "resolved": "https://registry.npmjs.org/@iiif/vocabulary/-/vocabulary-1.0.11.tgz",
+          "integrity": "sha512-JjPbZ+SCn0ljsfs9Nf0U1OWNZK7tauw7iHezDJA+28AAzmMwpFS/lTOe/4N0ynZsnk4x7cA9NL6CK3K0zDd50w=="
         },
         "@types/jquery": {
           "version": "3.3.14",
@@ -2088,43 +2081,49 @@
             "@types/sizzle": "*"
           }
         },
+        "@types/node": {
+          "version": "8.10.52",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.52.tgz",
+          "integrity": "sha512-2RbW7WXeLex6RI+kQSxq6Ym0GiVcODeQ4Km7MnnTX5BHdOGQnqVa+s6AUmAW+OFYAJ8wv9QxvNZXm7/kBdGTVw=="
+        },
         "manifesto.js": {
-          "version": "3.0.9",
-          "resolved": "https://registry.npmjs.org/manifesto.js/-/manifesto.js-3.0.9.tgz",
-          "integrity": "sha512-sblQSbDmPszfwqdcSVOZp0eXIFMg7vUYJKIVTGRoO65HBppjS9ipRZ+jReV3dt5WQhI5J58KXJL97z5mcKL/pA==",
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/manifesto.js/-/manifesto.js-4.0.1.tgz",
+          "integrity": "sha512-COHlq5zd+qWk7rP1iWAbSN9aMw+xPpSgKl9MVvvT3RP8J7mvY4wVsifyJTPdpJBV2k8hjjvACET/Qz2tzVwcqw==",
           "requires": {
-            "exjs": "github:BSick7/exjs#0.5.0",
-            "http-status-codes": "github:edsilv/http-status-codes#v0.0.7",
-            "request": "^2.83.0"
+            "@edsilv/http-status-codes": "^1.0.3",
+            "@iiif/vocabulary": "^1.0.11",
+            "isomorphic-unfetch": "^3.0.0"
           }
         }
       }
     },
     "@iiif/iiif-metadata-component": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/@iiif/iiif-metadata-component/-/iiif-metadata-component-1.1.13.tgz",
-      "integrity": "sha512-57GboCZo+5AZwhSge1vFSs7Ax9COdIYVBBXeVr+Xohx7s935oX3wJU+TWtzw94rKzc6hPpqzsUv8hq/NnMRTBA==",
+      "version": "1.1.19",
+      "resolved": "https://registry.npmjs.org/@iiif/iiif-metadata-component/-/iiif-metadata-component-1.1.19.tgz",
+      "integrity": "sha512-ghrejvw2aTIZOFGay82dmz0LewMt0K5Dyto1veZMdAqhRUuuGFC7g9DZhGZn4238XHuOsHa6QUH2ymvmZMCPBw==",
       "requires": {
-        "@edsilv/exjs": "0.5.1",
-        "@edsilv/jquery-plugins": "1.0.3",
-        "@edsilv/utils": "0.2.2",
-        "@iiif/base-component": "1.1.3",
-        "@iiif/manifold": "1.2.36",
+        "@edsilv/jquery-plugins": "1.0.7",
+        "@edsilv/utils": "1.0.2",
+        "@iiif/base-component": "2.0.1",
+        "@iiif/manifold": "2.0.2",
+        "@iiif/vocabulary": "1.0.11",
         "@types/jquery": "3.3.14",
-        "manifesto.js": "3.0.9"
+        "manifesto.js": "4.0.1"
       },
       "dependencies": {
-        "@edsilv/jquery-plugins": {
+        "@edsilv/http-status-codes": {
           "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/@edsilv/jquery-plugins/-/jquery-plugins-1.0.3.tgz",
-          "integrity": "sha512-nEQtgmVoKI3gELpKOGj69i1hxXIO4Ex+MaL0adPvoQiuQNj6+1+voxDCSzpkBudfiRTnjiVkhdF9By2ClTA86Q=="
+          "resolved": "https://registry.npmjs.org/@edsilv/http-status-codes/-/http-status-codes-1.0.3.tgz",
+          "integrity": "sha512-HLK2FS5sZqxPqD53D6hhZxC6C8THTVwlyZDZ7J0iWsrB8JmMA69m/CQuNKZc1kki9WSVeck2fXna26NL0SE7cg=="
         },
         "@edsilv/utils": {
-          "version": "0.2.2",
-          "resolved": "https://registry.npmjs.org/@edsilv/utils/-/utils-0.2.2.tgz",
-          "integrity": "sha512-SmB5GSsYdRPxslJM1taCNN46wuA3ETrFfET4KPGm5oKKOywczv30x3pRZ4bYv3pixSc3W9fwD4QFjNMpTkH1uw==",
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/@edsilv/utils/-/utils-1.0.2.tgz",
+          "integrity": "sha512-sSq1Rcixz/X1GoL9Bf1LdAZ4icfxXARj5RgysG2eJhSuM/7QXZEbOzoayo/DJro1qJgC4j8oXCneSeKuN9qa+A==",
           "requires": {
-            "@types/jquery": "^2.0.40"
+            "@types/jquery": "^2.0.40",
+            "@types/node": "8.10.52"
           },
           "dependencies": {
             "@types/jquery": {
@@ -2135,36 +2134,27 @@
           }
         },
         "@iiif/base-component": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/@iiif/base-component/-/base-component-1.1.3.tgz",
-          "integrity": "sha512-N9w7XfRnlV+13niU0ug7KoNRO55pBRowCF2sS60Bob4Fv98uqYh4LyL/R0z7y1yMFo5dJ6jp19p34KvwnhbUeg==",
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/@iiif/base-component/-/base-component-2.0.1.tgz",
+          "integrity": "sha512-BbIyUinIYMfre6hZYLjkhXjlt6KB9yEuO3onUQcOatBmepe8cTFNov16GzwgMcNXU2tvzCXuZLSN73Nf1295BA==",
           "requires": {
-            "@types/jquery": "^2.0.49",
-            "@types/node": "^7.0.65",
-            "typescript": "^2.8.3"
-          },
-          "dependencies": {
-            "@types/jquery": {
-              "version": "2.0.56",
-              "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-2.0.56.tgz",
-              "integrity": "sha512-tcNulMBr4fuMeBhwrRNQw3JaWg7vXP9bi64nKM5qYbaIN/oyo4n9O4TG5Thyn1BmhH159XvDxD4y3kqqpYS4sg=="
-            }
+            "@types/node": "8.10.52"
           }
         },
         "@iiif/manifold": {
-          "version": "1.2.36",
-          "resolved": "https://registry.npmjs.org/@iiif/manifold/-/manifold-1.2.36.tgz",
-          "integrity": "sha512-0WrvgyMhQs8Hz8USjOjAIdY1HN8RtZU5vUWen3YPlQJDoFqt6O0+lm+aWLDB9PITgLLVaTwhbyiDmL9nIxG7Gg==",
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/@iiif/manifold/-/manifold-2.0.2.tgz",
+          "integrity": "sha512-wZL7JzIGL09O1yIdaI+5tGuwhtIjOyL1SJN8mHsBiRKZqahDtsp/BkDQA7xM8XzDBzUhvobYNRuLnfZ1fQTJ2Q==",
           "requires": {
-            "@types/jquery": "^2.0.40"
-          },
-          "dependencies": {
-            "@types/jquery": {
-              "version": "2.0.56",
-              "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-2.0.56.tgz",
-              "integrity": "sha512-tcNulMBr4fuMeBhwrRNQw3JaWg7vXP9bi64nKM5qYbaIN/oyo4n9O4TG5Thyn1BmhH159XvDxD4y3kqqpYS4sg=="
-            }
+            "@edsilv/http-status-codes": "^1.0.3",
+            "@iiif/vocabulary": "^1.0.11",
+            "manifesto.js": "4.0.1"
           }
+        },
+        "@iiif/vocabulary": {
+          "version": "1.0.11",
+          "resolved": "https://registry.npmjs.org/@iiif/vocabulary/-/vocabulary-1.0.11.tgz",
+          "integrity": "sha512-JjPbZ+SCn0ljsfs9Nf0U1OWNZK7tauw7iHezDJA+28AAzmMwpFS/lTOe/4N0ynZsnk4x7cA9NL6CK3K0zDd50w=="
         },
         "@types/jquery": {
           "version": "3.3.14",
@@ -2174,14 +2164,19 @@
             "@types/sizzle": "*"
           }
         },
+        "@types/node": {
+          "version": "8.10.52",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.52.tgz",
+          "integrity": "sha512-2RbW7WXeLex6RI+kQSxq6Ym0GiVcODeQ4Km7MnnTX5BHdOGQnqVa+s6AUmAW+OFYAJ8wv9QxvNZXm7/kBdGTVw=="
+        },
         "manifesto.js": {
-          "version": "3.0.9",
-          "resolved": "https://registry.npmjs.org/manifesto.js/-/manifesto.js-3.0.9.tgz",
-          "integrity": "sha512-sblQSbDmPszfwqdcSVOZp0eXIFMg7vUYJKIVTGRoO65HBppjS9ipRZ+jReV3dt5WQhI5J58KXJL97z5mcKL/pA==",
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/manifesto.js/-/manifesto.js-4.0.1.tgz",
+          "integrity": "sha512-COHlq5zd+qWk7rP1iWAbSN9aMw+xPpSgKl9MVvvT3RP8J7mvY4wVsifyJTPdpJBV2k8hjjvACET/Qz2tzVwcqw==",
           "requires": {
-            "exjs": "github:BSick7/exjs#0.5.0",
-            "http-status-codes": "github:edsilv/http-status-codes#v0.0.7",
-            "request": "^2.83.0"
+            "@edsilv/http-status-codes": "^1.0.3",
+            "@iiif/vocabulary": "^1.0.11",
+            "isomorphic-unfetch": "^3.0.0"
           }
         }
       }
@@ -2250,13 +2245,26 @@
       }
     },
     "@iiif/manifold": {
-      "version": "1.2.38",
-      "resolved": "https://registry.npmjs.org/@iiif/manifold/-/manifold-1.2.38.tgz",
-      "integrity": "sha512-Bafem30hh7m3Zt6IP2S1cfaBoe8N6owMMCX8ogya/BJgu/7pO+RivVndOkYNAYrA3lyQ3YA9g8NRDB+w4vAorQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@iiif/manifold/-/manifold-2.0.4.tgz",
+      "integrity": "sha512-ANxF5gyulwejdi7GsyVVzNt5Ehch0RUd3pMa1t5K8fUxehV4iSModyvB5z3o4EHFeRjUljgK+pL589rlkwo5Og==",
       "requires": {
-        "@types/jquery": "^2.0.40",
-        "natives": "^1.1.6"
+        "@edsilv/http-status-codes": "^1.0.3",
+        "@iiif/vocabulary": "^1.0.20",
+        "manifesto.js": "^4.2.4"
+      },
+      "dependencies": {
+        "@edsilv/http-status-codes": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/@edsilv/http-status-codes/-/http-status-codes-1.0.3.tgz",
+          "integrity": "sha512-HLK2FS5sZqxPqD53D6hhZxC6C8THTVwlyZDZ7J0iWsrB8JmMA69m/CQuNKZc1kki9WSVeck2fXna26NL0SE7cg=="
+        }
       }
+    },
+    "@iiif/vocabulary": {
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/@iiif/vocabulary/-/vocabulary-1.0.20.tgz",
+      "integrity": "sha512-cL30/fL+7D+3tJvgGNZE6jWWGe/03ooEmwIfZEezbSE8mNzJB1pKthOrERKbeoMPdk1Qc++ySPgbgeawtYiFzA=="
     },
     "@types/jquery": {
       "version": "2.0.56",
@@ -2875,6 +2883,15 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
     },
+    "isomorphic-unfetch": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-unfetch/-/isomorphic-unfetch-3.1.0.tgz",
+      "integrity": "sha512-geDJjpoZ8N0kWexiwkX8F9NkTsXhetLPVbZFQ+JTW239QNOwvB0gniuR1Wc6f0AMTn7/mFGyXvHTifrCp/GH8Q==",
+      "requires": {
+        "node-fetch": "^2.6.1",
+        "unfetch": "^4.2.0"
+      }
+    },
     "isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
@@ -2997,12 +3014,26 @@
       "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
     "manifesto.js": {
-      "version": "3.0.12",
-      "resolved": "https://registry.npmjs.org/manifesto.js/-/manifesto.js-3.0.12.tgz",
-      "integrity": "sha512-AUrU2YH+TJW4BvgJrU1tPLH9wZZvNSSsgSha+4Sdei80/wUQqnUOFhTOkiYaf8fPNQa3nbaXnbbzz835vX8r3Q==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/manifesto.js/-/manifesto.js-4.2.4.tgz",
+      "integrity": "sha512-Kfa3RSFnWeLTmzpkRQu/WM1275cx859rzwQO0wiRVo3Kl3yjbyV7QPzZkLCqgaL76gOarfYe28t1EDytgGpL9A==",
       "requires": {
-        "http-status-codes": "github:edsilv/http-status-codes#v0.0.7",
-        "request": "^2.83.0"
+        "@edsilv/http-status-codes": "^1.0.3",
+        "@iiif/vocabulary": "^1.0.20",
+        "isomorphic-unfetch": "^3.0.0",
+        "lodash": "^4.17.21"
+      },
+      "dependencies": {
+        "@edsilv/http-status-codes": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/@edsilv/http-status-codes/-/http-status-codes-1.0.3.tgz",
+          "integrity": "sha512-HLK2FS5sZqxPqD53D6hhZxC6C8THTVwlyZDZ7J0iWsrB8JmMA69m/CQuNKZc1kki9WSVeck2fXna26NL0SE7cg=="
+        },
+        "lodash": {
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+        }
       }
     },
     "marks-pane": {
@@ -3054,11 +3085,6 @@
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
     },
-    "natives": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.6.tgz",
-      "integrity": "sha512-6+TDFewD4yxY14ptjKaS63GVdtKiES1pTPyxn9Jb0rBqPMZ7VcCiooEhPNsr+mqHtMGxa/5c/HhcC4uPEUw/nA=="
-    },
     "next-tick": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
@@ -3068,6 +3094,11 @@
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/node-ensure/-/node-ensure-0.0.0.tgz",
       "integrity": "sha1-7K52QVDemYYexcgQ/V0Jaxg5Mqc="
+    },
+    "node-fetch": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
     },
     "oauth-sign": {
       "version": "0.9.0",
@@ -3449,10 +3480,15 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.9.2.tgz",
       "integrity": "sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w=="
     },
+    "unfetch": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/unfetch/-/unfetch-4.2.0.tgz",
+      "integrity": "sha512-F9p7yYCn6cIW9El1zi0HI6vqpeIvBsr3dSuRO6Xuppb1u5rXpCPmMvLSyECLhybr9isec8Ohl0hPekMVrEinDA=="
+    },
     "universalviewer": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/universalviewer/-/universalviewer-3.1.1.tgz",
-      "integrity": "sha512-OiVFrvVX6GhDSt/g3fW6L/2SNzv0q3igvb1vmvLMcGVZBjle4P/oggNR7jx20mmVS8rNvnMUQD80Ay32O220hw==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/universalviewer/-/universalviewer-3.1.2.tgz",
+      "integrity": "sha512-QhEIwvJW6IKfAUMKzhPNDVLAGHx8uavhZqOrtQOuVV7ETwSh5iD3rGflPpSuF+mfGgkCMdg+8pXIG1DgcFUKFg==",
       "requires": {
         "@edsilv/exjs": "0.5.1",
         "@edsilv/http-status-codes": "0.0.12",
@@ -3460,11 +3496,12 @@
         "@edsilv/key-codes": "0.0.9",
         "@edsilv/utils": "0.2.6",
         "@iiif/base-component": "1.1.4",
-        "@iiif/iiif-av-component": "0.0.93",
-        "@iiif/iiif-gallery-component": "1.1.13",
-        "@iiif/iiif-metadata-component": "1.1.13",
+        "@iiif/iiif-av-component": "^1.1.1",
+        "@iiif/iiif-gallery-component": "1.1.19",
+        "@iiif/iiif-metadata-component": "1.1.19",
         "@iiif/iiif-tree-component": "1.1.16",
-        "@iiif/manifold": "1.2.38",
+        "@iiif/manifold": "^2.0.4",
+        "@iiif/vocabulary": "^1.0.20",
         "@types/modernizr": "3.2.29",
         "@types/requirejs": "2.1.28",
         "@types/three": "0.84.20",
@@ -3479,7 +3516,7 @@
         "jquery-ui-dist": "1.12.1",
         "jquery-ui-touch-punch": "0.2.3",
         "jsviews": "0.9.83",
-        "manifesto.js": "3.0.12",
+        "manifesto.js": "^4.2.4",
         "mediaelement": "4.0.2",
         "opencollective": "1.0.3",
         "openseadragon": "2.2.1",

--- a/package.json
+++ b/package.json
@@ -8,15 +8,15 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/UCLALibrary/UniversalViewer.git"
+    "url": "git+https://github.com/UCLALibrary/dl-viewer.git"
   },
   "author": "",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/UCLALibrary/UniversalViewer/issues"
+    "url": "https://github.com/UCLALibrary/dl-viewer/issues"
   },
-  "homepage": "https://github.com/UCLALibrary/UniversalViewer#readme",
+  "homepage": "https://github.com/UCLALibrary/dl-viewer#readme",
   "dependencies": {
-    "universalviewer": "^3.1"
+    "universalviewer": "^3.1.2"
   }
 }


### PR DESCRIPTION
This adds support for accompanyingCanvas in IIIF manifests, at our request.

Currently on dev with all media types working:
Image: https://d-w-dl-viewer01.library.ucla.edu/uv.html#?manifest=https%3A%2F%2Fiiif.library.ucla.edu%2Fark%253A%252F21198%252Fzz0002jvh5%2Fmanifest
Audio: https://d-w-dl-viewer01.library.ucla.edu/uv.html#?manifest=https%3A%2F%2Fiiif.library.ucla.edu%2Fark%253A%252F21198%252Fzz002dw0ff%2Fmanifest
Video: https://d-w-dl-viewer01.library.ucla.edu/uv.html#?manifest=https%3A%2F%2Fiiif.library.ucla.edu%2Fark%253A%252F21198%252Fzz002hdsj2%2Fmanifest

The new version still reports itself as 3.1.1 (in the settings panel), but this seems to be hard-coded and incorrect. The source (https://d-w-dl-viewer01.library.ucla.edu/uv.js) differs from the version of 3.1.1 currently on test (https://t-w-dl-viewer01.library.ucla.edu/uv.js), and a search for "accompanyingCanvas" shows the new additions.