### PR TITLE
copy `uv.html` to `index.html`

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,3 +2,4 @@ rm -rf dist
 npm install
 cp -r ./node_modules/universalviewer/dist ./
 cp ./src/* dist/
+cp dist/uv.html dist/index.html


### PR DESCRIPTION
When we transition dl-viewer to a vue shim that doesn't just load UV, we want to change the filename portion of it's URL to match. This PR is an interim step that supports the new filename with the old dl-viewer, so that we can change Ursus without breaking anything