### PR TITLE
enable Google Tag Manager

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "mediaelement": "^4.2.16",
     "universalviewer": "^3.1.4",
     "video.js": "^7.14.3",
-    "vue": "^3.0.0"
+    "vue": "^3.0.0",
+    "vue-gtm": "^3.5.0"
   },
   "devDependencies": {
     "@vue/cli-plugin-babel": "~4.5.0",

--- a/public/uv.html
+++ b/public/uv.html
@@ -63,6 +63,15 @@
       });
     }, false);
   </script>
+
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-T2SXV2');</script>
+  <!-- End Google Tag Manager -->
+
   <style>
     body {
       margin: 0;

--- a/src/components/VideoJS.vue
+++ b/src/components/VideoJS.vue
@@ -30,6 +30,7 @@ export default {
     };
   },
   mounted() {
+    this.$gtm.enable(true);
     this.player = videojs(
       this.$refs.videoPlayer,
       this.options,
@@ -42,6 +43,7 @@ export default {
     if (this.player) {
       this.player.dispose();
     }
+    this.$gtm.enable(false);
   },
 };
 </script>

--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,18 @@
 import { createApp } from "vue";
+import { createGtm } from "vue-gtm";
 import App from "./App.vue";
 
-createApp(App).mount("#app");
+const app = createApp(App)
+app.mount("#app");
+
+app.use(
+  createGtm({
+    id: "GTM-T2SXV2", // Your GTM single container ID, array of container ids ['GTM-xxxxxx', 'GTM-yyyyyy'] or array of objects [{id: 'GTM-xxxxxx', queryParams: { gtm_auth: 'abc123', gtm_preview: 'env-4', gtm_cookies_win: 'x'}}, {id: 'GTM-yyyyyy', queryParams: {gtm_auth: 'abc234', gtm_preview: 'env-5', gtm_cookies_win: 'x'}}], // Your GTM single container ID or array of container ids ['GTM-xxxxxx', 'GTM-yyyyyy']
+    defer: false, // Script can be set to `defer` to speed up page load at the cost of less accurate results (in case visitor leaves before script is loaded, which is unlikely but possible). Defaults to false, so the script is loaded `async` by default
+    compatibility: false, // Will add `async` and `defer` to the script tag to not block requests for old browsers that do not support `async`
+    nonce: "2726c7f26c", // Will add `nonce` to the script tag
+    enabled: false, // defaults to true. Plugin can be disabled by setting this to false for Ex: enabled: !!GDPR_Cookie (optional)
+    loadScript: true, // Whether or not to load the GTM Script (Helpful if you are including GTM manually, but need the dataLayer functionality in your components) (optional)
+    trackOnNextTick: false, // Whether or not call trackView in Vue.nextTick
+  })
+);


### PR DESCRIPTION
Since Universal Viewer loads within an inner iframe, but VideoJS loads as part of the main Vue app, this inserts GTM in both places, but only enables it within the main app if the VideoJS component is mounted.