### PR TITLE
feat: display static images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,11 +6,15 @@ on:
   pull_request:
     branches: [ main ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   cypress:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
+    - uses: actions/checkout@v4
     - uses: actions/setup-node@v3
       with:
         node-version: 16
@@ -24,7 +28,7 @@ jobs:
     # needs: cypress
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
         with:
           node-version: 16

--- a/cypress/integration/collection.spec.js
+++ b/cypress/integration/collection.spec.js
@@ -1,5 +1,5 @@
 describe('A IIIF Collection', () => {
-  const URL_PARAMETERS = '#?manifest=https%3A%2F%2Ftest.iiif.library.ucla.edu%2Fcollections%2Fark%253A%252F21198%252Fz11c574k';
+  const URL_PARAMETERS = '#?manifest=https%3A%2F%2Fiiif.library.ucla.edu%2Fcollections%2Fark%253A%252F21198%252Fz11c574k';
 
     it('loads Universal Viewer in an iframe', () => {
       cy.visit('/' + URL_PARAMETERS)

--- a/cypress/integration/image_static.spec.js
+++ b/cypress/integration/image_static.spec.js
@@ -1,0 +1,17 @@
+describe("A static image", () => {
+  const URL_PARAMETERS =
+    "?manifest=https%3A%2F%2Fiiif.library.ucla.edu%2Fark%253A%252F13030%252Fm5rc4g26%2Fmanifest"
+  it("uses an image tag", () => {
+    cy.visit("/" + URL_PARAMETERS)
+
+    // UV loads inside an iframe
+    cy.get("img")
+      .should(
+        "have.attr",
+        "src",
+        "https://d7rm5xoig729r.cloudfront.net/collectiveaccess/images/7/3/70105_ca_object_representations_media_7324_original.jpg"
+      )
+      .should("exist")
+      .should("be.visible")
+  })
+})

--- a/src/components/DLViewer.vue
+++ b/src/components/DLViewer.vue
@@ -9,7 +9,6 @@
 
 import axios from "axios";
 import { defineAsyncComponent } from "vue";
-import _has from "lodash/has"
 import _get from "lodash/get"
 
 export default {
@@ -56,20 +55,17 @@ export default {
       const iiifServicePath = this.isV3Manifest ?
         "iiif_manifest.items[0].items[0].items[0].body.service" :
         "iiif_manifest.sequences[0].canvases[0].images[0].resource.service"
-      console.log(this.isV3Manifest, iiifServicePath, _get(this, iiifServicePath))
-      const parts = iiifServicePath.split(".")
-      for (let i = 0; i < parts.length - 1; i++) {
-        let path = parts.slice(0, i + 1).join(".")
-        console.log(path, _get(this, path))
-      }
-      return _has(this, iiifServicePath)
+      return !!_get(this, iiifServicePath)
     },
     isChoice() {
       return (this.firstItemType == "Choice")
     },
     isCollection() {
       // Have seen "'@type': 'sc:Collection'" and "'type': 'Collection'"
-      return _get(this, "iiif_manifest.@type", _get(this, "iiif_manifest.type", "")).includes("Collection")
+      return (
+        _get(this, "iiif_manifest.@type")
+        || _get(this, "iiif_manifest.type", "")
+      ).includes("Collection")
     },
     isImage() {
       return (this.firstItemType == "Image")
@@ -136,7 +132,6 @@ export default {
       }
     },
     viewer() {
-      console.log(this.isSinaiPalimpsest, this.isSinai, this.isCollection, this.isVideo, this.isSound, this.isImage, this.hasIiifService)
       return (
         this.isSinaiPalimpsest ? "MiradorPalimpsest" :
         this.isSinai ? "Mirador" :

--- a/src/components/ImageTag.vue
+++ b/src/components/ImageTag.vue
@@ -1,5 +1,8 @@
 <template>
-  <img v-bind="options" class="image-tag" />
+  <img v-if="options.src" v-bind="options" class="image-tag" />
+  <div v-else class="image-tag">
+    <!-- CSS Placeholder w/o broken image icon -->
+  </div>
 </template>
 
 <script>
@@ -21,5 +24,6 @@ export default {
   height: 100%;
 
   object-fit: contain;
+  background-color: black;
 }
 </style>

--- a/src/components/ImageTag.vue
+++ b/src/components/ImageTag.vue
@@ -1,0 +1,25 @@
+<template>
+  <img v-bind="options" class="image-tag" />
+</template>
+
+<script>
+export default {
+  name: "ImageTag",
+  props: {
+    options: {
+      // { src: [...] }
+      type: Object,
+      required: true,
+    },
+  },
+};
+</script>
+
+<style>
+.image-tag {
+  width: 100%;
+  height: 100%;
+
+  object-fit: contain;
+}
+</style>


### PR DESCRIPTION
Our current version of universal viewer fails to render images that are included as a simple file link, instead of a iiif (ie, cantaloupe) service. This is fixed in UV 4.0.25, but other of our options break. This PR renders these images as a simple <img> tag, instead of using UV.

Also fixes an issue where collection documents are misidentified as Images. We were looking for `iiif_manifest.type: "Collection"` when the manifest had `iiif_manifest.@type: "sc:Collection"`. This wasn't an issue previously because images and collections were both passed on to UV.