### PR TITLE
Don't delete removed files when deploying

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
         if: env.DESTINATION_DIR
         uses: jakejarvis/s3-sync-action@be0c4ab89158cac4278689ebedd8407dd5f35a83
         with:
-          args: --follow-symlinks --delete
+          args: --follow-symlinks
         env:
           AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_KEY_ID }}


### PR DESCRIPTION
Our current build attaches content hashes to some filenames, which change when the files are updated. But we've run into problems where an old version of an un-hashed file (e.g. index.html) links to a deleted filename that wasn't itself hashed, causing the viewer to fail to load (this happend with both cloudfront and browser caches). There's probably an elegant solution if you understand http headers and web caching, but in the meantime we'll just leave the old versions sitting around.